### PR TITLE
Set Elo minimum to +- 10 to copy FaceIT's system

### DIFF
--- a/src/content/libs/elo.js
+++ b/src/content/libs/elo.js
@@ -5,8 +5,8 @@ export function calculateRatingChange(elo1, elo2, K = 50) {
   const eloDiff = elo2 - elo1
   const percentage = 1 / (1 + Math.pow(10, eloDiff / 400))
 
-  const winPoints = Math.round(K * (1 - percentage))
-  const lossPoints = Math.round(K * (0 - percentage))
+  const winPoints = Math.max(10, Math.round(K * (1 - percentage)))
+  const lossPoints = Math.max(10, Math.round(K * (0 - percentage)))
 
   return {
     winPoints,


### PR DESCRIPTION
As can be seen [here](https://faceitstats.com/profile,name,clug), Elo for winning against significantly lower rated players is capped at +10, despite the plugin currently displaying a potential +6 for winning in [this room](https://www.faceit.com/en/csgo/room/ec871565-810e-40be-8ac6-f3f6c95c5d62).